### PR TITLE
The active_time column in the pg_stat_database table does not exist.

### DIFF
--- a/collector/gs_stat_database.go
+++ b/collector/gs_stat_database.go
@@ -249,9 +249,9 @@ func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance
 	}
 
 	activeTimeAvail := instance.version.GTE(semver.MustParse("14.0.0"))
-	if activeTimeAvail {
+	/*if activeTimeAvail {
 		columns = append(columns, "active_time")
-	}
+	}*/
 
 	rows, err := db.QueryContext(ctx,
 		statDatabaseQuery(columns),

--- a/collector/gs_stat_database_test.go
+++ b/collector/gs_stat_database_test.go
@@ -54,7 +54,7 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 		"blk_read_time",
 		"blk_write_time",
 		"stats_reset",
-		"active_time",
+		//"active_time",
 	}
 
 	srT, err := time.Parse("2006-01-02 15:04:05.00000-07", "2023-05-25 17:10:42.81132-07")
@@ -165,7 +165,7 @@ func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
 		"blk_read_time",
 		"blk_write_time",
 		"stats_reset",
-		"active_time",
+		//"active_time",
 	}
 
 	rows := sqlmock.NewRows(columns).
@@ -287,7 +287,7 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 		"blk_read_time",
 		"blk_write_time",
 		"stats_reset",
-		"active_time",
+		//"active_time",
 	}
 
 	srT, err := time.Parse("2006-01-02 15:04:05.00000-07", "2023-05-25 17:10:42.81132-07")
@@ -456,7 +456,7 @@ func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
 		"blk_read_time",
 		"blk_write_time",
 		"stats_reset",
-		"active_time",
+		//"active_time",
 	}
 
 	rows := sqlmock.NewRows(columns).


### PR DESCRIPTION
time=2025-09-05T09:34:16.484+08:00 level=ERROR source=collector.go:207 msg="collector failed" name=stat_database duration_seconds=0.1799696 err="ERROR: Column \"active_time\" does not exist. (SQLSTATE 42703)"