### PR TITLE
The n_mod_since_analyze column does not exist in the pg_stat_user_tables table.

### DIFF
--- a/collector/gs_stat_user_tables.go
+++ b/collector/gs_stat_user_tables.go
@@ -96,12 +96,12 @@ var (
 		[]string{"datname", "schemaname", "relname"},
 		prometheus.Labels{},
 	)
-	statUserTablesNModSinceAnalyze = prometheus.NewDesc(
+	/*statUserTablesNModSinceAnalyze = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, userTableSubsystem, "n_mod_since_analyze"),
 		"Estimated number of rows changed since last analyze",
 		[]string{"datname", "schemaname", "relname"},
 		prometheus.Labels{},
-	)
+	)*/
 	statUserTablesLastVacuum = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, userTableSubsystem, "last_vacuum"),
 		"Last time at which this table was manually vacuumed (not counting VACUUM FULL)",
@@ -163,6 +163,7 @@ var (
 		prometheus.Labels{},
 	)
 
+	// n_mod_since_analyze,
 	statUserTablesQuery = `SELECT
 		current_database() datname,
 		schemaname,
@@ -177,7 +178,7 @@ var (
 		n_tup_hot_upd,
 		n_live_tup,
 		n_dead_tup,
-		n_mod_since_analyze,
+		
 		COALESCE(last_vacuum, '1970-01-01Z') as last_vacuum,
 		COALESCE(last_autovacuum, '1970-01-01Z') as last_autovacuum,
 		COALESCE(last_analyze, '1970-01-01Z') as last_analyze,
@@ -335,7 +336,7 @@ func (c *PGStatUserTablesCollector) Update(ctx context.Context, instance *instan
 			datnameLabel, schemanameLabel, relnameLabel,
 		)
 
-		nModSinceAnalyzeMetric := 0.0
+		/*nModSinceAnalyzeMetric := 0.0
 		if nModSinceAnalyze.Valid {
 			nModSinceAnalyzeMetric = float64(nModSinceAnalyze.Int64)
 		}
@@ -344,7 +345,7 @@ func (c *PGStatUserTablesCollector) Update(ctx context.Context, instance *instan
 			prometheus.GaugeValue,
 			nModSinceAnalyzeMetric,
 			datnameLabel, schemanameLabel, relnameLabel,
-		)
+		)*/
 
 		lastVacuumMetric := 0.0
 		if lastVacuum.Valid {

--- a/collector/gs_stat_user_tables_test.go
+++ b/collector/gs_stat_user_tables_test.go
@@ -49,6 +49,7 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 		t.Fatalf("Error parsing vacuum time: %s", err)
 	}
 
+	// "n_mod_since_analyze",
 	columns := []string{
 		"datname",
 		"schemaname",
@@ -63,7 +64,7 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 		"n_tup_hot_upd",
 		"n_live_tup",
 		"n_dead_tup",
-		"n_mod_since_analyze",
+
 		"last_vacuum",
 		"last_autovacuum",
 		"last_analyze",
@@ -154,6 +155,7 @@ func TestPGStatUserTablesCollectorNullValues(t *testing.T) {
 
 	inst := &instance{db: db}
 
+	// "n_mod_since_analyze",
 	columns := []string{
 		"datname",
 		"schemaname",
@@ -168,7 +170,7 @@ func TestPGStatUserTablesCollectorNullValues(t *testing.T) {
 		"n_tup_hot_upd",
 		"n_live_tup",
 		"n_dead_tup",
-		"n_mod_since_analyze",
+
 		"last_vacuum",
 		"last_autovacuum",
 		"last_analyze",


### PR DESCRIPTION
time=2025-09-05T09:34:16.792+08:00 level=ERROR source=collector.go:207 msg="collector failed" name=stat_user_tables duration_seconds=0.4879153 err="ERROR: Column \"n_mod_since_analyze\" does not exist. (SQLSTATE 42703)"