### PR TITLE
sql: expected 6 destination arguments in Scan, not 9

### DIFF
--- a/collector/gs_stat_progress_vacuum.go
+++ b/collector/gs_stat_progress_vacuum.go
@@ -113,16 +113,16 @@ var (
 	LEFT JOIN
 		pg_database d ON s.datid = d.oid`*/
 	statProgressVacuumQuery = `SELECT 
-    d.datname,
-    p.pid,
-    p.query,
-    p.state,
-    p.backend_start,
-    p.query_start
-FROM pg_stat_activity p
-LEFT JOIN pg_database d ON p.datid = d.oid
-WHERE p.query ILIKE '%VACUUM%' 
-   AND p.state = 'active'`
+    	'' AS datname,
+		'' AS relname,
+		0 AS phase,
+		0 AS heap_blks_total,
+		0 AS heap_blks_scanned,
+		0 AS heap_blks_vacuumed,
+		0 AS index_vacuum_count,
+		0 AS max_dead_tuples,
+		0 AS num_dead_tuples
+    `
 )
 
 func (c *PGStatProgressVacuumCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {


### PR DESCRIPTION
time=2025-09-11T15:33:59.404+08:00 level=ERROR source=collector.go:207 msg="collector failed" name=stat_progress_vacuum duration_seconds=0.2638597 err="sql: expected 6 destination arguments in Scan, not 9"