### PR TITLE
sql: expected 23 destination arguments in Scan, not 24

### DIFF
--- a/collector/gs_stat_user_tables.go
+++ b/collector/gs_stat_user_tables.go
@@ -178,7 +178,7 @@ var (
 		n_tup_hot_upd,
 		n_live_tup,
 		n_dead_tup,
-		
+		0,
 		COALESCE(last_vacuum, '1970-01-01Z') as last_vacuum,
 		COALESCE(last_autovacuum, '1970-01-01Z') as last_autovacuum,
 		COALESCE(last_analyze, '1970-01-01Z') as last_analyze,


### PR DESCRIPTION
time=2025-09-10T18:03:40.290+08:00 level=ERROR source=collector.go:207 msg="collector failed" name=stat_user_tables duration_seconds=0.4060955 err="sql: expected 23 destination arguments in Scan, not 24"