### PR TITLE
sql: Scan error on column index 2, name "current_wal_lsn": converting driver.Value type string ("0/0") to a float64: invalid syntax

### DIFF
--- a/collector/gs_replication_slot.go
+++ b/collector/gs_replication_slot.go
@@ -109,7 +109,7 @@ var (
 	pgReplicationSlotNewQuery = `SELECT
 		slot_name,
 		slot_type,
-		'0/0'
+		0
 		AS current_wal_lsn,
 		'0/0' AS confirmed_flush_lsn,
 		active,


### PR DESCRIPTION
time=2025-09-17T11:09:28.740+08:00 level=ERROR source=collector.go:207 msg="collector failed" name=replication_slot duration_seconds=0.6087117 err="sql: Scan error on column index 2, name \"current_wal_lsn\": converting driver.Value type string (\"0/0\") to a float64: invalid syntax"