### PR TITLE
sql: Scan error on column index 3, name "confirmed_flush_lsn": converting driver.Value type string ("0/0") to a float64: invalid syntax

### DIFF
--- a/collector/gs_replication_slot.go
+++ b/collector/gs_replication_slot.go
@@ -92,9 +92,9 @@ var (
 	pgReplicationSlotQuery = `SELECT
 		slot_name,
 		slot_type,
-		'0/0'
+		0
 		AS current_wal_lsn,
-		'0/0' AS confirmed_flush_lsn,
+		0 AS confirmed_flush_lsn,
 		active
 	FROM pg_replication_slots;`
 
@@ -111,7 +111,7 @@ var (
 		slot_type,
 		0
 		AS current_wal_lsn,
-		'0/0' AS confirmed_flush_lsn,
+		0 AS confirmed_flush_lsn,
 		active,
 		0,
 		''


### PR DESCRIPTION
time=2025-09-17T11:14:38.977+08:00 level=ERROR source=collector.go:207 msg="collector failed" name=replication_slot duration_seconds=0.7635459 err="sql: Scan error on column index 3, name \"confirmed_flush_lsn\": converting driver.Value type string (\"0/0\") to a float64: invalid syntax"