### PR TITLE
TestPGStatDatabaseCollectorNullValues panic: Expected number of values to match number of columns

### DIFF
--- a/collector/gs_stat_database_test.go
+++ b/collector/gs_stat_database_test.go
@@ -136,7 +136,7 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 	}
 }
 
-/*func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
+func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Error opening a stub db connection: %s", err)
@@ -169,7 +169,7 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 		"blk_read_time",
 		"blk_write_time",
 		"stats_reset",
-		"active_time",
+		//"active_time",
 	}
 
 	rows := sqlmock.NewRows(columns).
@@ -193,7 +193,7 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 			16,
 			823,
 			srT,
-			32,
+			//32,
 		).
 		AddRow(
 			"pid",
@@ -215,7 +215,7 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 			16,
 			823,
 			srT,
-			32,
+			//32,
 		)
 	mock.ExpectQuery(sanitizeQuery(statDatabaseQuery(columns))).WillReturnRows(rows)
 
@@ -254,16 +254,20 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range expected {
-			m := readMetric(<-ch)
-			convey.So(expect, convey.ShouldResemble, m)
+			m, ok := <-ch
+			if !ok {
+				break
+			}
+			result := readMetric(m)
+			convey.So(expect, convey.ShouldResemble, result)
 		}
 	})
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}
-}*/
+}
 
-/*func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
+func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Error opening a stub db connection: %s", err)
@@ -430,9 +434,9 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}
-}*/
+}
 
-/*func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
+func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Error opening a stub db connection: %s", err)
@@ -532,4 +536,4 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}
-}*/
+}


### PR DESCRIPTION
TestPGStatDatabaseCollectorNullValues panic: Expected number of values to match number of columns: expected 20, actual 19 [recovered, repanicked].