### PR TITLE
Fix version parsing for openGauss-lite in GaussDB exporter integration test

### DIFF
--- a/cmd/gaussdb_exporter/gaussdb_exporter.go
+++ b/cmd/gaussdb_exporter/gaussdb_exporter.go
@@ -77,8 +77,8 @@ type MappingOptions struct {
 type Mapping map[string]MappingOptions
 
 // Regex used to get the "short-version" from the GaussDB version field.
-var versionRegex = regexp.MustCompile(`GaussDB Kernel (\d+\.\d+\.\d+)`)
-var lowestSupportedVersion = semver.MustParse("505.0.0")
+var versionRegex = regexp.MustCompile(`(?:GaussDB Kernel|openGauss-lite) (\d+\.\d+\.\d+)`)
+var lowestSupportedVersion = semver.MustParse("7.0.0")
 
 // Parses the version of gaussdb into the short version string we can use to
 // match behaviors.


### PR DESCRIPTION
The integration test currently fails when encountering the openGauss-lite version string format. The error occurs because the version regex pattern does not account for the "openGauss-lite" prefix in the version output.