### PR TITLE
Should omit type interface{} from declaration; it will be inferred from the right-hand side.

### DIFF
--- a/tool/array.go
+++ b/tool/array.go
@@ -742,7 +742,7 @@ func appendArrayElement(b []byte, rv reflect.Value) ([]byte, string, error) {
 
 	var del = ","
 	var err error
-	var iv interface{} = rv.Interface()
+	var iv = rv.Interface()
 
 	if ad, ok := iv.(ArrayDelimiter); ok {
 		del = ad.ArrayDelimiter()


### PR DESCRIPTION
Should omit type interface{} from declaration; it will be inferred from the right-hand side.