### PR TITLE
reflect.PtrTo has been deprecated since Go 1.22 and an alternative has been available since Go 1.18: Superseded by [PointerTo].

### DIFF
--- a/tool/array.go
+++ b/tool/array.go
@@ -368,7 +368,7 @@ func (GenericArray) evaluateDestination(rt reflect.Type) (reflect.Type, func([]b
 	// TODO calculate the assign function for other types
 	// TODO repeat this section on the element type of arrays or slices (multidimensional)
 	{
-		if reflect.PtrTo(rt).Implements(typeSQLScanner) {
+		if reflect.PointerTo(rt).Implements(typeSQLScanner) {
 			// dest is always addressable because it is an element of a slice.
 			assign = func(src []byte, dest reflect.Value) (err error) {
 				ss := dest.Addr().Interface().(sql.Scanner)


### PR DESCRIPTION
reflect.PtrTo has been deprecated since Go 1.22 and an alternative has been available since Go 1.18: Superseded by [PointerTo].