### PR TITLE
Pause pushing the gaussdb_prometheus-exporter Docker image to quay.io.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
         # docker_hub_organization: prometheuscommunity
         docker_hub_organization: hwcdtse
         # quay_io_organization: prometheuscommunity
-        quay_io_organization: moseszane168
+        # quay_io_organization: moseszane168
         requires:
         - test
         - build_all
@@ -92,7 +92,7 @@ workflows:
         # docker_hub_organization: prometheuscommunity
         docker_hub_organization: hwcdtse
         # quay_io_organization: prometheuscommunity
-        quay_io_organization: moseszane168
+        # quay_io_organization: moseszane168
         requires:
         - test
         - build_all


### PR DESCRIPTION
Pause pushing the gaussdb_prometheus-exporter Docker image to quay.io.